### PR TITLE
Add domain option for industry-focused inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,14 +293,18 @@ python convert.py --hf-ckpt-path /path/to/DeepSeek-V3 --save-path /path/to/DeepS
 Then you can chat with DeepSeek-V3:
 
 ```shell
-torchrun --nnodes 2 --nproc-per-node 8 --node-rank $RANK --master-addr $ADDR generate.py --ckpt-path /path/to/DeepSeek-V3-Demo --config configs/config_671B.json --interactive --temperature 0.7 --max-new-tokens 200
+torchrun --nnodes 2 --nproc-per-node 8 --node-rank $RANK --master-addr $ADDR generate.py --ckpt-path /path/to/DeepSeek-V3-Demo --config configs/config_671B.json --interactive --temperature 0.7 --max-new-tokens 200 --domain consulting
 ```
+
+Use the `--domain` option to specialize responses for a particular service industry.
 
 Or batch inference on a given file:
 
 ```shell
-torchrun --nnodes 2 --nproc-per-node 8 --node-rank $RANK --master-addr $ADDR generate.py --ckpt-path /path/to/DeepSeek-V3-Demo --config configs/config_671B.json --input-file $FILE
+torchrun --nnodes 2 --nproc-per-node 8 --node-rank $RANK --master-addr $ADDR generate.py --ckpt-path /path/to/DeepSeek-V3-Demo --config configs/config_671B.json --input-file $FILE --domain finance
 ```
+
+The domain flag accepts `consulting`, `finance`, `law`, or `general`.
 
 ### 6.2 Inference with SGLang (recommended)
 


### PR DESCRIPTION
## Summary
- add predefined service-industry prompts and `--domain` CLI argument
- insert system message before generation based on domain
- update README usage examples

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844fd3808d8832ea4f4ef4df0947d9e